### PR TITLE
Use the new url of the documentation website

### DIFF
--- a/src/components/CountDownAndHomeCastle/CountDownAndHomeCastle.tsx
+++ b/src/components/CountDownAndHomeCastle/CountDownAndHomeCastle.tsx
@@ -74,7 +74,7 @@ export const CountDownAndHomeCastle: React.FC<{
     );
 
     const openDoc = useCallback(
-        () => window.open("http://funcamp-r.pages.lab.sspcloud.fr/funcamp-r/#pages/joueurs/"),
+        () => window.open("http://inseefrlab.github.io/funcamp-r/#pages/joueurs/"),
         []
     );
 

--- a/src/components/Home/Home.tsx
+++ b/src/components/Home/Home.tsx
@@ -26,7 +26,7 @@ export const Home: React.FC<{
                     </p>
 
                     <button
-                        onClick={useCallback(() => window.open("http://funcamp-r.pages.lab.sspcloud.fr/funcamp-r/#pages/joueurs/"), [])}
+                        onClick={useCallback(() => window.open("http://inseefrlab.github.io/funcamp-r/#pages/joueurs/"), [])}
                     >Accéder au jeu et aux tutoriels R</button>
 
                 </div>
@@ -68,7 +68,7 @@ export const Home: React.FC<{
                     </p>
 
                     <button
-                        onClick={useCallback(() => window.open("http://funcamp-r.pages.lab.sspcloud.fr/funcamp-r/#pages/joueurs/"), [])}
+                        onClick={useCallback(() => window.open("http://inseefrlab.github.io/funcamp-r/#pages/joueurs/"), [])}
                     >Consulter la documentation</button>
 
                 </div>


### PR DESCRIPTION
Les repos officiels du Funcamp R sont désormais hébergés sur https://github.com/InseeFrLab afin de leur offrir une meilleure visibilité et de rendre possibles les contributions externes.

Cette PR met à jour les urls vers le site de documentation du projet.